### PR TITLE
Fix Mod Menu Integration with Embeddium

### DIFF
--- a/src/main/java/me/cortex/voxy/client/config/ModMenuIntegration.java
+++ b/src/main/java/me/cortex/voxy/client/config/ModMenuIntegration.java
@@ -2,18 +2,33 @@ package me.cortex.voxy.client.config;
 
 import com.terraformersmc.modmenu.api.ConfigScreenFactory;
 import com.terraformersmc.modmenu.api.ModMenuApi;
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
 import me.cortex.voxy.common.Logger;
 import me.cortex.voxy.commonImpl.VoxyCommon;
 import me.jellysquid.mods.sodium.client.gui.SodiumOptionsGUI;
+import net.minecraft.client.gui.screens.Screen;
 
 public class ModMenuIntegration implements ModMenuApi {
     @Override
     public ConfigScreenFactory<?> getModConfigScreenFactory() {
         return parent -> {
             if (VoxyCommon.isAvailable()) {
-                var screen = (SodiumOptionsGUI) SodiumOptionsGUI.createScreen(parent);
-                //Sorry jelly and douira, please dont hurt me
+				//Sorry jelly and douira, please dont hurt me
+				
+                SodiumOptionsGUI screen = null;
+				if (Arrays.stream(SodiumOptionsGUI.class.getMethods()).anyMatch(method -> method.getName().equals("createScreen"))) {
+					screen = (SodiumOptionsGUI) SodiumOptionsGUI.createScreen(parent);
+				}
+				
                 try {
+					if (screen == null) {
+						// Embeddium support
+						Constructor<SodiumOptionsGUI> constructor = SodiumOptionsGUI.class.getDeclaredConstructor(Screen.class);
+						constructor.setAccessible(true);
+						screen = constructor.newInstance(parent);
+					}
+					
                     //We cant use .setPage() as that invokes rebuildGui, however the screen hasnt been initalized yet
                     // causing things to crash
                     var field = SodiumOptionsGUI.class.getDeclaredField("currentPage");

--- a/src/main/java/me/cortex/voxy/client/config/ModMenuIntegration.java
+++ b/src/main/java/me/cortex/voxy/client/config/ModMenuIntegration.java
@@ -2,11 +2,13 @@ package me.cortex.voxy.client.config;
 
 import com.terraformersmc.modmenu.api.ConfigScreenFactory;
 import com.terraformersmc.modmenu.api.ModMenuApi;
-import java.lang.reflect.Constructor;
-import java.util.Arrays;
+
+import me.cortex.voxy.client.mixin.sodium.AccessorSodiumOptionsGUI;
 import me.cortex.voxy.common.Logger;
 import me.cortex.voxy.commonImpl.VoxyCommon;
+import me.jellysquid.mods.sodium.client.SodiumClientMod;
 import me.jellysquid.mods.sodium.client.gui.SodiumOptionsGUI;
+import me.jellysquid.mods.sodium.client.gui.screen.ConfigCorruptedScreen;
 import net.minecraft.client.gui.screens.Screen;
 
 public class ModMenuIntegration implements ModMenuApi {
@@ -14,21 +16,10 @@ public class ModMenuIntegration implements ModMenuApi {
     public ConfigScreenFactory<?> getModConfigScreenFactory() {
         return parent -> {
             if (VoxyCommon.isAvailable()) {
-				//Sorry jelly and douira, please dont hurt me
-				
-                SodiumOptionsGUI screen = null;
-				if (Arrays.stream(SodiumOptionsGUI.class.getMethods()).anyMatch(method -> method.getName().equals("createScreen"))) {
-					screen = (SodiumOptionsGUI) SodiumOptionsGUI.createScreen(parent);
-				}
+                Screen screen = SodiumClientMod.options().isReadOnly() ? new ConfigCorruptedScreen(parent, AccessorSodiumOptionsGUI::newScreen) : AccessorSodiumOptionsGUI.newScreen(parent);
+                //Sorry jelly and douira, please dont hurt me
 				
                 try {
-					if (screen == null) {
-						// Embeddium support
-						Constructor<SodiumOptionsGUI> constructor = SodiumOptionsGUI.class.getDeclaredConstructor(Screen.class);
-						constructor.setAccessible(true);
-						screen = constructor.newInstance(parent);
-					}
-					
                     //We cant use .setPage() as that invokes rebuildGui, however the screen hasnt been initalized yet
                     // causing things to crash
                     var field = SodiumOptionsGUI.class.getDeclaredField("currentPage");

--- a/src/main/java/me/cortex/voxy/client/mixin/sodium/AccessorSodiumOptionsGUI.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/sodium/AccessorSodiumOptionsGUI.java
@@ -1,0 +1,14 @@
+package me.cortex.voxy.client.mixin.sodium;
+
+import me.jellysquid.mods.sodium.client.gui.SodiumOptionsGUI;
+import net.minecraft.client.gui.screens.Screen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(SodiumOptionsGUI.class)
+public interface AccessorSodiumOptionsGUI {
+    @Invoker(value = "<init>")
+    static SodiumOptionsGUI newScreen(Screen currentScreen) {
+        throw new AssertionError(); // Used for Embeddium support
+    }
+}

--- a/src/main/resources/client.voxy.mixins.json
+++ b/src/main/resources/client.voxy.mixins.json
@@ -31,6 +31,7 @@
     "nvidium.MixinRenderPipeline",
     "sodium.AccessorChunkTracker",
     "sodium.AccessorSodiumWorldRenderer",
+    "sodium.AccessorSodiumOptionsGUI",
     "sodium.MixinChunkJobQueue",
     // "sodium.MixinDefaultChunkRenderer",
     "sodium.MixinRenderSectionManager",


### PR DESCRIPTION
Use ~reflection~ Mixin when createScreen is not available.
This fixes compat with custom Sodium forks such as Embeddium.