### PR TITLE
Sodium 0.5.13 compat, downgrade to LWJGL 3.3.1 and Integer/Long expansion based on MR-JAR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -263,7 +263,7 @@ remapJar {
     }
 }
 
-project.ext.lwjglVersion = "3.3.3"
+project.ext.lwjglVersion = "3.3.1"
 project.ext.lwjglNatives = "natives-windows"
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -184,9 +184,9 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 java {
-    def javaVersion = JavaVersion.toVersion(targetJavaVersion)
+    def javaVersion = JavaVersion.toVersion(21)
     if (JavaVersion.current() < javaVersion) {
-        toolchain.languageVersion = JavaLanguageVersion.of(targetJavaVersion)
+        toolchain.languageVersion = JavaLanguageVersion.of(21)
     }
 
     // Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
@@ -197,7 +197,38 @@ java {
     //withSourcesJar()
 }
 
-jar {
+sourceSets {
+    main {
+        java.srcDirs = ['src/main/java']
+    }
+    java21 {
+        java.srcDirs = ['src/java21/java']
+        compileClasspath += sourceSets.main.output
+    }
+}
+
+tasks.register('compileJava21', JavaCompile) {
+    source = sourceSets.java21.java
+    classpath = sourceSets.java21.compileClasspath
+    destinationDirectory = layout.buildDirectory.dir("classes/java21")
+
+    options.release = 21
+}
+
+tasks.jar {
+    dependsOn(tasks.compileJava21)
+
+    from(tasks.compileJava21.destinationDirectory) {
+        into("META-INF/versions/21")
+        duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
+
+    manifest {
+        attributes(
+                "Multi-Release": "true"
+        )
+    }
+
     from("LICENSE") {
         rename { "${it}_${project.archives_base_name}"}
     }
@@ -251,6 +282,13 @@ processIncludeJars {
 }
 
 remapJar {
+    dependsOn(tasks.compileJava21)
+
+    from(tasks.compileJava21.destinationDirectory) {
+        into("META-INF/versions/21")
+        duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
+
     doFirst {
         delete fileTree(getDestinationDirectory().get())
     }

--- a/src/java21/java/me/cortex/voxy/client/core/util/ExpansionUtil.java
+++ b/src/java21/java/me/cortex/voxy/client/core/util/ExpansionUtil.java
@@ -1,0 +1,24 @@
+package me.cortex.voxy.client.core.util;
+
+public class ExpansionUtil {
+
+    public static int expand(int i, int mask) {
+        return Integer.expand(i, mask);
+    }
+
+    public static int compress(int i, int mask) {
+        return Integer.compress(i, mask);
+    }
+
+    public static long expand(long i, long mask) {
+        return Long.expand(i, mask);
+    }
+
+    public static long compress(long i, long mask) {
+        return Long.compress(i, mask);
+    }
+
+    public static boolean isJava21() {
+        return true;
+    }
+}

--- a/src/main/java/me/cortex/voxy/client/GPUSelectorWindows2.java
+++ b/src/main/java/me/cortex/voxy/client/GPUSelectorWindows2.java
@@ -1,11 +1,12 @@
 package me.cortex.voxy.client;
 
+import me.cortex.voxy.client.compat.Kernel32;
 import me.cortex.voxy.common.Logger;
 import org.lwjgl.system.JNI;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.system.MemoryUtil;
+import org.lwjgl.system.SharedLibrary;
 import org.lwjgl.system.windows.GDI32;
-import org.lwjgl.system.windows.Kernel32;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -13,9 +14,17 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
-import static org.lwjgl.system.APIUtil.apiGetFunctionAddressOptional;
+import static org.lwjgl.system.MemoryUtil.NULL;
 
 public class GPUSelectorWindows2 {
+    private static long apiGetFunctionAddressOptional(SharedLibrary library, String functionName) {
+        long a = library.getFunctionAddress(functionName);
+        if (a == NULL) {
+            Logger.error("[LWJGL] Failed to locate address for " + library.getName() + " function " + functionName + "\n");
+        }
+        return a;
+    }
+
     private static final long D3DKMTSetProperties = apiGetFunctionAddressOptional(GDI32.getLibrary(), "D3DKMTSetProperties");
     private static final long D3DKMTEnumAdapters2 = apiGetFunctionAddressOptional(GDI32.getLibrary(), "D3DKMTEnumAdapters2");
     private static final long D3DKMTCloseAdapter = apiGetFunctionAddressOptional(GDI32.getLibrary(), "D3DKMTCloseAdapter");

--- a/src/main/java/me/cortex/voxy/client/VoxyClient.java
+++ b/src/main/java/me/cortex/voxy/client/VoxyClient.java
@@ -2,6 +2,7 @@ package me.cortex.voxy.client;
 
 import me.cortex.voxy.client.core.gl.Capabilities;
 import me.cortex.voxy.client.core.rendering.util.SharedIndexBuffer;
+import me.cortex.voxy.client.core.util.ExpansionUtil;
 import me.cortex.voxy.common.Logger;
 import me.cortex.voxy.commonImpl.VoxyCommon;
 import net.fabricmc.api.ClientModInitializer;
@@ -60,6 +61,10 @@ public class VoxyClient implements ClientModInitializer {
                 Logger.warn("GPU does not support subgroup operations, expect some performance degradation");
             }
 
+        }
+
+        if (!ExpansionUtil.isJava21()) {
+            Logger.warn("Cannot use native Integer/Long compression. Using fallback...");
         }
     }
 

--- a/src/main/java/me/cortex/voxy/client/compat/Kernel32.java
+++ b/src/main/java/me/cortex/voxy/client/compat/Kernel32.java
@@ -1,0 +1,150 @@
+package me.cortex.voxy.client.compat;
+
+import me.cortex.voxy.common.Logger;
+import org.lwjgl.system.*;
+
+import static org.lwjgl.system.APIUtil.*;
+import static org.lwjgl.system.Checks.*;
+import static org.lwjgl.system.JNI.*;
+import static org.lwjgl.system.MemoryUtil.NULL;
+
+/** Native bindings to Kernel32 library. */
+public class Kernel32 {
+
+    private static SharedLibrary KERNEL32;
+
+    /** Contains the function pointers loaded from the kernel32 {@link SharedLibrary}. */
+    public static final class Functions {
+
+        private Functions() {}
+
+        /** Function address. */
+        public static Long GetCurrentProcess, GetCurrentProcessId, GetProcessId, GetCurrentThread, GetCurrentThreadId, GetThreadId, GetProcessIdOfThread, GetCurrentProcessorNumber;
+
+        public static void init() {
+            if (GetCurrentProcess == null)
+                GetCurrentProcess           = apiGetFunctionAddress(Kernel32.getLibrary(), "GetCurrentProcess");
+            if (GetCurrentProcessId == null)
+                GetCurrentProcessId         = apiGetFunctionAddress(Kernel32.getLibrary(), "GetCurrentProcessId");
+            if (GetProcessId == null)
+                GetProcessId                = apiGetFunctionAddress(Kernel32.getLibrary(), "GetProcessId");
+            if (GetCurrentThread == null)
+                GetCurrentThread            = apiGetFunctionAddress(Kernel32.getLibrary(), "GetCurrentThread");
+            if (GetCurrentThreadId == null)
+                GetCurrentThreadId          = apiGetFunctionAddress(Kernel32.getLibrary(), "GetCurrentThreadId");
+            if (GetThreadId == null)
+                GetThreadId                 = apiGetFunctionAddressOptional(Kernel32.getLibrary(), "GetThreadId");
+            if (GetProcessIdOfThread == null)
+                GetProcessIdOfThread        = apiGetFunctionAddressOptional(Kernel32.getLibrary(), "GetProcessIdOfThread");
+            if (GetCurrentProcessorNumber == null)
+                GetCurrentProcessorNumber   = apiGetFunctionAddressOptional(Kernel32.getLibrary(), "GetCurrentProcessorNumber");
+        }
+
+        private static long apiGetFunctionAddressOptional(SharedLibrary library, String functionName) {
+            long a = library.getFunctionAddress(functionName);
+            if (a == NULL) {
+                Logger.error("[LWJGL] Failed to locate address for " + library.getName() + " function " + functionName + "\n");
+            }
+            return a;
+        }
+    }
+
+    /** Returns the kernel32 {@link SharedLibrary}. */
+    public static SharedLibrary getLibrary() {
+        if (KERNEL32 == null) {
+            KERNEL32 = Library.loadNative(me.cortex.voxy.client.compat.Kernel32.class, "org.lwjgl", "kernel32");
+        }
+        return KERNEL32;
+    }
+
+    protected Kernel32() {
+        throw new UnsupportedOperationException();
+    }
+
+    // --- [ GetCurrentProcess ] ---
+
+    @NativeType("HANDLE")
+    public static long GetCurrentProcess() {
+        me.cortex.voxy.client.compat.Kernel32.Functions.init();
+        long __functionAddress = me.cortex.voxy.client.compat.Kernel32.Functions.GetCurrentProcess;
+        return callP(__functionAddress);
+    }
+
+    // --- [ GetCurrentProcessId ] ---
+
+    @NativeType("DWORD")
+    public static int GetCurrentProcessId() {
+        me.cortex.voxy.client.compat.Kernel32.Functions.init();
+        long __functionAddress = me.cortex.voxy.client.compat.Kernel32.Functions.GetCurrentProcessId;
+        return callI(__functionAddress);
+    }
+
+    // --- [ GetProcessId ] ---
+
+    @NativeType("DWORD")
+    public static int GetProcessId(@NativeType("HANDLE") long Process) {
+        me.cortex.voxy.client.compat.Kernel32.Functions.init();
+        long __functionAddress = me.cortex.voxy.client.compat.Kernel32.Functions.GetProcessId;
+        if (CHECKS) {
+            check(Process);
+        }
+        return callPI(Process, __functionAddress);
+    }
+
+    // --- [ GetCurrentThread ] ---
+
+    @NativeType("HANDLE")
+    public static long GetCurrentThread() {
+        me.cortex.voxy.client.compat.Kernel32.Functions.init();
+        long __functionAddress = me.cortex.voxy.client.compat.Kernel32.Functions.GetCurrentThread;
+        return callP(__functionAddress);
+    }
+
+    // --- [ GetCurrentThreadId ] ---
+
+    @NativeType("DWORD")
+    public static int GetCurrentThreadId() {
+        me.cortex.voxy.client.compat.Kernel32.Functions.init();
+        long __functionAddress = me.cortex.voxy.client.compat.Kernel32.Functions.GetCurrentThreadId;
+        return callI(__functionAddress);
+    }
+
+    // --- [ GetThreadId ] ---
+
+    @NativeType("DWORD")
+    public static int GetThreadId(@NativeType("HANDLE") long Thread) {
+        me.cortex.voxy.client.compat.Kernel32.Functions.init();
+        long __functionAddress = me.cortex.voxy.client.compat.Kernel32.Functions.GetThreadId;
+        if (CHECKS) {
+            check(__functionAddress);
+            check(Thread);
+        }
+        return callPI(Thread, __functionAddress);
+    }
+
+    // --- [ GetProcessIdOfThread ] ---
+
+    @NativeType("DWORD")
+    public static int GetProcessIdOfThread(@NativeType("HANDLE") long Thread) {
+        me.cortex.voxy.client.compat.Kernel32.Functions.init();
+        long __functionAddress = me.cortex.voxy.client.compat.Kernel32.Functions.GetProcessIdOfThread;
+        if (CHECKS) {
+            check(__functionAddress);
+            check(Thread);
+        }
+        return callPI(Thread, __functionAddress);
+    }
+
+    // --- [ GetCurrentProcessorNumber ] ---
+
+    @NativeType("DWORD")
+    public static int GetCurrentProcessorNumber() {
+        me.cortex.voxy.client.compat.Kernel32.Functions.init();
+        long __functionAddress = me.cortex.voxy.client.compat.Kernel32.Functions.GetCurrentProcessorNumber;
+        if (CHECKS) {
+            check(__functionAddress);
+        }
+        return callI(__functionAddress);
+    }
+
+}

--- a/src/main/java/me/cortex/voxy/client/config/ModMenuIntegration.java
+++ b/src/main/java/me/cortex/voxy/client/config/ModMenuIntegration.java
@@ -2,16 +2,20 @@ package me.cortex.voxy.client.config;
 
 import com.terraformersmc.modmenu.api.ConfigScreenFactory;
 import com.terraformersmc.modmenu.api.ModMenuApi;
+import me.cortex.voxy.client.mixin.sodium.AccessorSodiumOptionsGUI;
 import me.cortex.voxy.common.Logger;
 import me.cortex.voxy.commonImpl.VoxyCommon;
+import me.jellysquid.mods.sodium.client.SodiumClientMod;
 import me.jellysquid.mods.sodium.client.gui.SodiumOptionsGUI;
+import me.jellysquid.mods.sodium.client.gui.screen.ConfigCorruptedScreen;
+import net.minecraft.client.gui.screens.Screen;
 
 public class ModMenuIntegration implements ModMenuApi {
     @Override
     public ConfigScreenFactory<?> getModConfigScreenFactory() {
         return parent -> {
             if (VoxyCommon.isAvailable()) {
-                var screen = (SodiumOptionsGUI) SodiumOptionsGUI.createScreen(parent);
+                Screen screen = SodiumClientMod.options().isReadOnly() ? new ConfigCorruptedScreen(parent, AccessorSodiumOptionsGUI::newScreen) : AccessorSodiumOptionsGUI.newScreen(parent);
                 //Sorry jelly and douira, please dont hurt me
                 try {
                     //We cant use .setPage() as that invokes rebuildGui, however the screen hasnt been initalized yet

--- a/src/main/java/me/cortex/voxy/client/core/rendering/building/OccupancySet.java
+++ b/src/main/java/me/cortex/voxy/client/core/rendering/building/OccupancySet.java
@@ -1,6 +1,6 @@
 package me.cortex.voxy.client.core.rendering.building;
 
-import me.cortex.voxy.client.core.util.ExpansionUgly;
+import me.cortex.voxy.client.core.util.ExpansionUtil;
 import org.lwjgl.system.MemoryUtil;
 
 import java.util.Arrays;
@@ -14,8 +14,8 @@ public class OccupancySet {
     private long topLvl;//4x4x4
     private final long[] bottomLvl = new long[(4*4*4)*8];
     public void set(final int pos) {
-        final long topBit = 1L<<ExpansionUgly.compress(pos, 0b11000_11000_11000);
-        final int  botIdx =     ExpansionUgly.compress(pos, 0b00111_00111_00111);
+        final long topBit = 1L<< ExpansionUtil.compress(pos, 0b11000_11000_11000);
+        final int  botIdx =     ExpansionUtil.compress(pos, 0b00111_00111_00111);
 
         int baseBotIdx = Long.bitCount(this.topLvl&(topBit-1))*8;
         if ((this.topLvl & topBit) == 0) {
@@ -39,8 +39,8 @@ public class OccupancySet {
     }
 
     private boolean get(int pos) {
-        final long topBit = 1L<<ExpansionUgly.compress(pos, 0b11000_11000_11000);
-        final int  botIdx =     ExpansionUgly.compress(pos, 0b00111_00111_00111);
+        final long topBit = 1L<< ExpansionUtil.compress(pos, 0b11000_11000_11000);
+        final int  botIdx =     ExpansionUtil.compress(pos, 0b00111_00111_00111);
         if ((this.topLvl & topBit) == 0) {
             return false;
         }

--- a/src/main/java/me/cortex/voxy/client/core/rendering/building/RenderDataFactory.java
+++ b/src/main/java/me/cortex/voxy/client/core/rendering/building/RenderDataFactory.java
@@ -3,7 +3,7 @@ package me.cortex.voxy.client.core.rendering.building;
 import me.cortex.voxy.client.core.model.IdNotYetComputedException;
 import me.cortex.voxy.client.core.model.ModelFactory;
 import me.cortex.voxy.client.core.model.ModelQueries;
-import me.cortex.voxy.client.core.util.ExpansionUgly;
+import me.cortex.voxy.client.core.util.ExpansionUtil;
 import me.cortex.voxy.client.core.util.ScanMesher2D;
 import me.cortex.voxy.common.Logger;
 import me.cortex.voxy.common.util.MemoryBuffer;
@@ -335,7 +335,7 @@ public class RenderDataFactory {
             //Note this is not thread safe! (but eh, fk it)
             var raw = sec._unsafeGetRawDataArray();
             for (int i = 0; i < 32*32; i++) {
-                this.neighboringFaces[i+32*32*4] = raw[ExpansionUgly.expand(i,0b11111_00000_11111)|(0x1F<<5)];//pull the +z faces from the section
+                this.neighboringFaces[i+32*32*4] = raw[ExpansionUtil.expand(i,0b11111_00000_11111)|(0x1F<<5)];//pull the +z faces from the section
             }
             sec.release(WorldSection.RELEASE_HINT_POSSIBLE_REUSE);
         }
@@ -344,7 +344,7 @@ public class RenderDataFactory {
             //Note this is not thread safe! (but eh, fk it)
             var raw = sec._unsafeGetRawDataArray();
             for (int i = 0; i < 32*32; i++) {
-                this.neighboringFaces[i+32*32*5] = raw[ExpansionUgly.expand(i,0b11111_00000_11111)];//pull the -z faces from the section
+                this.neighboringFaces[i+32*32*5] = raw[ExpansionUtil.expand(i,0b11111_00000_11111)];//pull the -z faces from the section
             }
             sec.release(WorldSection.RELEASE_HINT_POSSIBLE_REUSE);
         }
@@ -900,9 +900,9 @@ public class RenderDataFactory {
                         this.xAxisMeshers[index].skip(31);
                     }
                     //Clear the sum
-                    sumA &= ~(ExpansionUgly.expand(Integer.toUnsignedLong(partialHasCount), X_I_MSK)*0x1F);
-                    sumB &= ~(ExpansionUgly.expand(Integer.toUnsignedLong(partialHasCount)>>11, X_I_MSK)*0x1F);
-                    sumC &= ~(ExpansionUgly.expand(Integer.toUnsignedLong(partialHasCount)>>22, X_I_MSK)*0x1F);
+                    sumA &= ~(ExpansionUtil.expand(Integer.toUnsignedLong(partialHasCount), X_I_MSK)*0x1F);
+                    sumB &= ~(ExpansionUtil.expand(Integer.toUnsignedLong(partialHasCount)>>11, X_I_MSK)*0x1F);
+                    sumC &= ~(ExpansionUtil.expand(Integer.toUnsignedLong(partialHasCount)>>22, X_I_MSK)*0x1F);
                 }
 
                 if (msk == 0) {
@@ -1105,9 +1105,9 @@ public class RenderDataFactory {
                         this.xAxisMeshers[index].skip(31);
                     }
                     //Clear the sum
-                    sumA &= ~(ExpansionUgly.expand(Integer.toUnsignedLong(partialHasCount), X_I_MSK)*0x1F);
-                    sumB &= ~(ExpansionUgly.expand(Integer.toUnsignedLong(partialHasCount)>>11, X_I_MSK)*0x1F);
-                    sumC &= ~(ExpansionUgly.expand(Integer.toUnsignedLong(partialHasCount)>>22, X_I_MSK)*0x1F);
+                    sumA &= ~(ExpansionUtil.expand(Integer.toUnsignedLong(partialHasCount), X_I_MSK)*0x1F);
+                    sumB &= ~(ExpansionUtil.expand(Integer.toUnsignedLong(partialHasCount)>>11, X_I_MSK)*0x1F);
+                    sumC &= ~(ExpansionUtil.expand(Integer.toUnsignedLong(partialHasCount)>>22, X_I_MSK)*0x1F);
                 }
 
                 if (msk == 0) {
@@ -1388,9 +1388,9 @@ public class RenderDataFactory {
                         this.secondaryXAxisMeshers[index].skip(31);
                     }
                     //Clear the sum
-                    sumA &= ~(ExpansionUgly.expand(Integer.toUnsignedLong(partialHasCount), X_I_MSK)*0x1F);
-                    sumB &= ~(ExpansionUgly.expand(Integer.toUnsignedLong(partialHasCount)>>11, X_I_MSK)*0x1F);
-                    sumC &= ~(ExpansionUgly.expand(Integer.toUnsignedLong(partialHasCount)>>22, X_I_MSK)*0x1F);
+                    sumA &= ~(ExpansionUtil.expand(Integer.toUnsignedLong(partialHasCount), X_I_MSK)*0x1F);
+                    sumB &= ~(ExpansionUtil.expand(Integer.toUnsignedLong(partialHasCount)>>11, X_I_MSK)*0x1F);
+                    sumC &= ~(ExpansionUtil.expand(Integer.toUnsignedLong(partialHasCount)>>22, X_I_MSK)*0x1F);
                 }
 
                 if (msk == 0) {

--- a/src/main/java/me/cortex/voxy/client/core/util/ExpansionUtil.java
+++ b/src/main/java/me/cortex/voxy/client/core/util/ExpansionUtil.java
@@ -1,6 +1,6 @@
 package me.cortex.voxy.client.core.util;
 
-public class ExpansionUgly {
+public class ExpansionUtil {
 
     private static int parallelSuffix(int maskCount) {
         int maskPrefix = maskCount ^ (maskCount << 1);
@@ -181,5 +181,9 @@ public class ExpansionUgly {
             maskCount = maskCount & ~maskPrefix;
         }
         return i;
+    }
+
+    public static boolean isJava21() {
+        return false;
     }
 }

--- a/src/main/java/me/cortex/voxy/client/mixin/ClientVoxyMixinPlugin.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/ClientVoxyMixinPlugin.java
@@ -1,0 +1,59 @@
+package me.cortex.voxy.client.mixin;
+
+import me.cortex.voxy.common.Logger;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Set;
+
+public class ClientVoxyMixinPlugin implements IMixinConfigPlugin {
+    private static boolean sodiumLegacy = true;
+
+    @Override
+    public void onLoad(String mixinPackage) {
+        try (InputStream stream = getClass().getClassLoader()
+                .getResourceAsStream("me/jellysquid/mods/sodium/client/render/SodiumWorldRenderer.class")) {
+
+            if (stream != null) {
+                ClassReader reader = new ClassReader(stream);
+                ClassNode node = new ClassNode();
+                reader.accept(node, 0);
+
+                for (MethodNode method : node.methods) {
+                    if (method.name.equals("drawChunkLayer") && method.desc.contains("ChunkRenderMatrices")) {
+                        sodiumLegacy = false;
+                        break;
+                    }
+                }
+            } else {
+                Logger.error("SodiumWorldRenderer class not found");
+            }
+        } catch (Exception e) {
+            Logger.error(e);
+        }
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) { return true; }
+
+    @Override public List<String> getMixins() {
+        return List.of(sodiumLegacy ? "sodium.MixinSodiumWorldRendererLegacy" : "sodium.MixinSodiumWorldRenderer");
+    }
+
+    @Override
+    public String getRefMapperConfig() { return null; }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {}
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
+}

--- a/src/main/java/me/cortex/voxy/client/mixin/sodium/AccessorSodiumOptionsGUI.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/sodium/AccessorSodiumOptionsGUI.java
@@ -1,0 +1,14 @@
+package me.cortex.voxy.client.mixin.sodium;
+
+import me.jellysquid.mods.sodium.client.gui.SodiumOptionsGUI;
+import net.minecraft.client.gui.screens.Screen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(SodiumOptionsGUI.class)
+public interface AccessorSodiumOptionsGUI {
+    @Invoker(value = "<init>")
+    static SodiumOptionsGUI newScreen(Screen currentScreen) {
+        throw new AssertionError(); // Used for Embeddium support
+    }
+}

--- a/src/main/java/me/cortex/voxy/client/mixin/sodium/MixinSodiumWorldRendererLegacy.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/sodium/MixinSodiumWorldRendererLegacy.java
@@ -1,11 +1,6 @@
 package me.cortex.voxy.client.mixin.sodium;
 
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
+import com.mojang.blaze3d.vertex.PoseStack;
 import me.cortex.voxy.client.core.IGetVoxyRenderSystem;
 import me.cortex.voxy.client.core.rendering.Viewport;
 import me.cortex.voxy.client.core.util.IrisUtil;
@@ -15,9 +10,15 @@ import me.jellysquid.mods.sodium.client.render.SodiumWorldRenderer;
 import me.jellysquid.mods.sodium.client.render.chunk.ChunkRenderMatrices;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderType;
+import org.spongepowered.asm.mixin.Dynamic;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(value = SodiumWorldRenderer.class, remap = false)
-public class MixinSodiumWorldRenderer {
+public class MixinSodiumWorldRendererLegacy {
     @Inject(method = "initRenderer", at = @At("TAIL"), remap = false)
     private void voxy$injectThreadUpdate(CommandList cl, CallbackInfo ci) {
         var vi = VoxyCommon.getInstance();
@@ -27,13 +28,15 @@ public class MixinSodiumWorldRenderer {
     @Unique
     private ChunkRenderMatrices voxy$capturedMatrices;
 
-    @Inject(method = "drawChunkLayer(Lnet/minecraft/client/renderer/RenderType;Lme/jellysquid/mods/sodium/client/render/chunk/ChunkRenderMatrices;DDD)V", at = @At("HEAD"))
-    private void voxy$captureMatrices(RenderType renderLayer, ChunkRenderMatrices matrices, double x, double y, double z, CallbackInfo ci) {
-        this.voxy$capturedMatrices = matrices;
+    @Dynamic
+    @Inject(method = "drawChunkLayer(Lnet/minecraft/class_1921;Lnet/minecraft/class_4587;DDD)V", at = @At("HEAD"))
+    private void voxy$captureMatrices(RenderType renderLayer, PoseStack matrixStack, double x, double y, double z, CallbackInfo ci) {
+        this.voxy$capturedMatrices = ChunkRenderMatrices.from(matrixStack);
     }
 
-    @Inject(method = "drawChunkLayer(Lnet/minecraft/client/renderer/RenderType;Lme/jellysquid/mods/sodium/client/render/chunk/ChunkRenderMatrices;DDD)V", at = @At("TAIL"))
-    private void injectRender(RenderType renderLayer, ChunkRenderMatrices matrices, double x, double y, double z, CallbackInfo ci) {
+    @Dynamic
+    @Inject(method = "drawChunkLayer(Lnet/minecraft/class_1921;Lnet/minecraft/class_4587;DDD)V", at = @At("TAIL"))
+    private void injectRender(RenderType renderLayer, PoseStack matrixStack, double x, double y, double z, CallbackInfo ci) {
         this.doRender(this.voxy$capturedMatrices, renderLayer, x, y, z);
     }
     

--- a/src/main/java/me/cortex/voxy/common/config/storage/rocksdb/RocksDBStorageBackend.java
+++ b/src/main/java/me/cortex/voxy/common/config/storage/rocksdb/RocksDBStorageBackend.java
@@ -1,7 +1,7 @@
 package me.cortex.voxy.common.config.storage.rocksdb;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import me.cortex.voxy.client.core.util.ExpansionUgly;
+import me.cortex.voxy.client.core.util.ExpansionUtil;
 import me.cortex.voxy.common.config.ConfigBuildCtx;
 import me.cortex.voxy.common.config.storage.StorageBackend;
 import me.cortex.voxy.common.config.storage.StorageConfig;
@@ -269,8 +269,8 @@ public class RocksDBStorageBackend extends StorageBackend {
         }
         if (WorldEngine.POS_FORMAT_VERSION != 1) throw new IllegalStateException("TODO: UPDATE THIS");
         return  (key&(0xFL<<60)) |
-                ExpansionUgly.expand((key>>> 4)&((1L<<24)-1), 0b01010101010101010101010101010101_001001001001001001001001L) |
-                ExpansionUgly.expand((key>>>52)&0xFF,         0b00000000000000000000000000000000_100100100100100100100100L) |
-                ExpansionUgly.expand((key>>>28)&((1L<<24)-1), 0b10101010101010101010101010101010_010010010010010010010010L);
+                ExpansionUtil.expand((key>>> 4)&((1L<<24)-1), 0b01010101010101010101010101010101_001001001001001001001001L) |
+                ExpansionUtil.expand((key>>>52)&0xFF,         0b00000000000000000000000000000000_100100100100100100100100L) |
+                ExpansionUtil.expand((key>>>28)&((1L<<24)-1), 0b10101010101010101010101010101010_010010010010010010010010L);
     }
 }

--- a/src/main/java/me/cortex/voxy/common/util/ThreadUtils.java
+++ b/src/main/java/me/cortex/voxy/common/util/ThreadUtils.java
@@ -1,8 +1,8 @@
 package me.cortex.voxy.common.util;
 
+import me.cortex.voxy.client.compat.Kernel32;
 import me.cortex.voxy.common.Logger;
 import org.lwjgl.system.*;
-import org.lwjgl.system.windows.Kernel32;
 
 //Platform specific code to assist in thread utilities
 public class ThreadUtils {
@@ -48,7 +48,7 @@ public class ThreadUtils {
         }
 
         if (masks == null) {
-            int retVal = JNI.invokePPCI(Kernel32.GetCurrentThread(), 0, (short) 0, SetThreadSelectedCpuSetMasks);
+            int retVal = 0; // JNI.invokePPCI(Kernel32.GetCurrentThread(), 0, (short) 0, SetThreadSelectedCpuSetMasks);
             if (retVal == 0) {
                 throw new IllegalStateException();
             }
@@ -66,7 +66,7 @@ public class ThreadUtils {
                 MemoryUtil.memPutShort(ptr+i*16L+8L, groups[i]);
             }
 
-            int retVal = JNI.invokePPCI(Kernel32.GetCurrentThread(), ptr, (short)masks.length, SetThreadSelectedCpuSetMasks);
+            int retVal = 0; // JNI.invokePPCI(Kernel32.GetCurrentThread(), ptr, (short)masks.length, SetThreadSelectedCpuSetMasks);
             if (retVal == 0) {
                 throw new IllegalStateException();
             }

--- a/src/main/java/me/cortex/voxy/common/voxelization/WorldConversionFactory.java
+++ b/src/main/java/me/cortex/voxy/common/voxelization/WorldConversionFactory.java
@@ -1,7 +1,7 @@
 package me.cortex.voxy.common.voxelization;
 
 import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
-import me.cortex.voxy.client.core.util.ExpansionUgly;
+import me.cortex.voxy.client.core.util.ExpansionUtil;
 import me.cortex.voxy.common.world.other.Mapper;
 import me.cortex.voxy.common.world.other.Mipper;
 import me.jellysquid.mods.lithium.common.world.chunk.LithiumHashPalette;
@@ -178,7 +178,7 @@ public class WorldConversionFactory {
 
                 byte light = lightSupplier.supply(i&0xF, (i>>8)&0xF, (i>>4)&0xF);
                 nonZeroCnt += (bId != 0)?1:0;
-                data[i] = Mapper.composeMappingId(light, bId, biomes[ExpansionUgly.compress(i,0b1100_1100_1100)]);
+                data[i] = Mapper.composeMappingId(light, bId, biomes[ExpansionUtil.compress(i,0b1100_1100_1100)]);
             }
         } else {
             if (!(blockContainer.data.storage instanceof ZeroBitStorage)) {
@@ -193,7 +193,7 @@ public class WorldConversionFactory {
                 nonZeroCnt = 4096;
                 for (int i = 0; i <= 0xFFF; i++) {
                     byte light = lightSupplier.supply(i&0xF, (i>>8)&0xF, (i>>4)&0xF);
-                    data[i] = Mapper.composeMappingId(light, bId, biomes[ExpansionUgly.compress(i,0b1100_1100_1100)]);
+                    data[i] = Mapper.composeMappingId(light, bId, biomes[ExpansionUtil.compress(i,0b1100_1100_1100)]);
                 }
             }
         }

--- a/src/main/java/me/cortex/voxy/common/world/SaveLoadSystem.java
+++ b/src/main/java/me/cortex/voxy/common/world/SaveLoadSystem.java
@@ -1,7 +1,7 @@
 package me.cortex.voxy.common.world;
 
 import it.unimi.dsi.fastutil.longs.Long2ShortOpenHashMap;
-import me.cortex.voxy.client.core.util.ExpansionUgly;
+import me.cortex.voxy.client.core.util.ExpansionUtil;
 import me.cortex.voxy.common.Logger;
 import me.cortex.voxy.common.util.MemoryBuffer;
 import me.cortex.voxy.common.util.UnsafeUtil;
@@ -18,15 +18,15 @@ public class SaveLoadSystem {
         int x = i&0x1F;
         int y = (i>>10)&0x1F;
         int z = (i>>5)&0x1F;
-        return ExpansionUgly.expand(x,0b1001001001001)|ExpansionUgly.expand(y,0b10010010010010)|ExpansionUgly.expand(z,0b100100100100100);
+        return ExpansionUtil.expand(x,0b1001001001001)| ExpansionUtil.expand(y,0b10010010010010)| ExpansionUtil.expand(z,0b100100100100100);
 
         //zyxzyxzyxzyxzyx
     }
 
     public static int z2lin(int i) {
-        int x = ExpansionUgly.compress(i, 0b1001001001001);
-        int y = ExpansionUgly.compress(i, 0b10010010010010);
-        int z = ExpansionUgly.compress(i, 0b100100100100100);
+        int x = ExpansionUtil.compress(i, 0b1001001001001);
+        int y = ExpansionUtil.compress(i, 0b10010010010010);
+        int z = ExpansionUtil.compress(i, 0b100100100100100);
         return x|(y<<10)|(z<<5);
     }
 

--- a/src/main/java/me/cortex/voxy/common/world/SaveLoadSystem2.java
+++ b/src/main/java/me/cortex/voxy/common/world/SaveLoadSystem2.java
@@ -1,7 +1,7 @@
 package me.cortex.voxy.common.world;
 
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
-import me.cortex.voxy.client.core.util.ExpansionUgly;
+import me.cortex.voxy.client.core.util.ExpansionUtil;
 import me.cortex.voxy.common.Logger;
 import me.cortex.voxy.common.util.MemoryBuffer;
 import me.cortex.voxy.common.util.UnsafeUtil;
@@ -17,15 +17,15 @@ public class SaveLoadSystem2 {
         int x = i&0x1F;
         int y = (i>>10)&0x1F;
         int z = (i>>5)&0x1F;
-        return ExpansionUgly.expand(x,0b1001001001001)|ExpansionUgly.expand(y,0b10010010010010)|ExpansionUgly.expand(z,0b100100100100100);
+        return ExpansionUtil.expand(x,0b1001001001001)| ExpansionUtil.expand(y,0b10010010010010)| ExpansionUtil.expand(z,0b100100100100100);
 
         //zyxzyxzyxzyxzyx
     }
 
     public static int z2lin(int i) {
-        int x = ExpansionUgly.compress(i, 0b1001001001001);
-        int y = ExpansionUgly.compress(i, 0b10010010010010);
-        int z = ExpansionUgly.compress(i, 0b100100100100100);
+        int x = ExpansionUtil.compress(i, 0b1001001001001);
+        int y = ExpansionUtil.compress(i, 0b10010010010010);
+        int z = ExpansionUtil.compress(i, 0b100100100100100);
         return x|(y<<10)|(z<<5);
     }
 

--- a/src/main/java/me/cortex/voxy/common/world/SaveLoadSystem3.java
+++ b/src/main/java/me/cortex/voxy/common/world/SaveLoadSystem3.java
@@ -1,7 +1,7 @@
 package me.cortex.voxy.common.world;
 
 import it.unimi.dsi.fastutil.longs.Long2ShortOpenHashMap;
-import me.cortex.voxy.client.core.util.ExpansionUgly;
+import me.cortex.voxy.client.core.util.ExpansionUtil;
 import me.cortex.voxy.common.Logger;
 import me.cortex.voxy.common.util.MemoryBuffer;
 import me.cortex.voxy.common.util.ThreadLocalMemoryBuffer;
@@ -21,15 +21,15 @@ public class SaveLoadSystem3 {
         int x = i&0x1F;
         int y = (i>>10)&0x1F;
         int z = (i>>5)&0x1F;
-        return ExpansionUgly.expand(x,0b1001001001001)|ExpansionUgly.expand(y,0b10010010010010)|ExpansionUgly.expand(z,0b100100100100100);
+        return ExpansionUtil.expand(x,0b1001001001001)| ExpansionUtil.expand(y,0b10010010010010)| ExpansionUtil.expand(z,0b100100100100100);
 
         //zyxzyxzyxzyxzyx
     }
 
     public static int z2lin(int i) {
-        int x = ExpansionUgly.compress(i, 0b1001001001001);
-        int y = ExpansionUgly.compress(i, 0b10010010010010);
-        int z = ExpansionUgly.compress(i, 0b100100100100100);
+        int x = ExpansionUtil.compress(i, 0b1001001001001);
+        int y = ExpansionUtil.compress(i, 0b10010010010010);
+        int z = ExpansionUtil.compress(i, 0b100100100100100);
         return x|(y<<10)|(z<<5);
     }
 

--- a/src/main/java/me/cortex/voxy/commonImpl/importers/DHImporter.java
+++ b/src/main/java/me/cortex/voxy/commonImpl/importers/DHImporter.java
@@ -1,6 +1,6 @@
 package me.cortex.voxy.commonImpl.importers;
 
-import me.cortex.voxy.client.core.util.ExpansionUgly;
+import me.cortex.voxy.client.core.util.ExpansionUtil;
 import me.cortex.voxy.common.Logger;
 import me.cortex.voxy.common.thread.Service;
 import me.cortex.voxy.common.thread.ServiceManager;
@@ -340,8 +340,8 @@ public class DHImporter implements IDataImporter {
         byte[] col = ctx.colScratch;
         for (int x = 0; x < 64; x++) {
             for (int z = 0; z < 64; z++) {
-                int bPos = ExpansionUgly.expand(x&0xF, 0b00_00_0000_0000_1111) |
-                           ExpansionUgly.expand(z, 0b00_11_0000_1111_0000);
+                int bPos = ExpansionUtil.expand(x&0xF, 0b00_00_0000_0000_1111) |
+                           ExpansionUtil.expand(z, 0b00_11_0000_1111_0000);
                 short cl = stream.readShort();
                 if (cl < 0) {
                     throw new IllegalStateException();
@@ -357,8 +357,8 @@ public class DHImporter implements IDataImporter {
                     //    int a = 0;
                     //}
                     //Insert all entries into data cache
-                    startY = ExpansionUgly.expand(startY, 0b11111111_00_1111_0000_0000);
-                    endY = ExpansionUgly.expand(endY, 0b11111111_00_1111_0000_0000);
+                    startY = ExpansionUtil.expand(startY, 0b11111111_00_1111_0000_0000);
+                    endY = ExpansionUtil.expand(endY, 0b11111111_00_1111_0000_0000);
                     final int Msk = 0b11111111_00_1111_0000_0000;
                     final int iMsk1 = (~Msk)+1;
                     for (int y = startY; y != endY; y = (y+iMsk1)&Msk) {

--- a/src/main/resources/client.voxy.mixins.json
+++ b/src/main/resources/client.voxy.mixins.json
@@ -1,6 +1,7 @@
 {
   "required": true,
   "package": "me.cortex.voxy.client.mixin",
+  "plugin": "me.cortex.voxy.client.mixin.ClientVoxyMixinPlugin",
   "compatibilityLevel": "JAVA_17",
   "client": [
     "iris.CustomUniformsAccessor",
@@ -27,11 +28,11 @@
     "minecraft.MixinWindow",
     "nvidium.MixinRenderPipeline",
     "sodium.AccessorChunkTracker",
+    "sodium.AccessorSodiumOptionsGUI",
     "sodium.AccessorSodiumWorldRenderer",
     "sodium.MixinChunkJobQueue",
     "sodium.MixinRenderSectionManager",
-    "sodium.MixinSodiumOptionsGUI",
-    "sodium.MixinSodiumWorldRenderer"
+    "sodium.MixinSodiumOptionsGUI"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Sodium 0.5.13 uses `ChunkRenderMatrices` instead of `PoseStack` in `Lme/jellysquid/mods/sodium/client/render/SodiumWorldRenderer;drawChunkLayer`, this PR makes voxy compatible with both. It also fixes embeddium compat with Mod Menu (again) and downgrades LWJGL to 3.3.1, making the mod compatible with the majority of Minecraft launchers without having to manually change LWJGL's version.

Edit: added Integer/Long expansion based on MR-JAR. Uses native .compress and .expand on Java 21 but fallbacks to ExpansionUgly on older versions automatically.