### PR TITLE
Don't use LWJGL class in CpuLayout

### DIFF
--- a/src/main/java/me/cortex/voxy/common/util/cpu/CpuLayout.java
+++ b/src/main/java/me/cortex/voxy/common/util/cpu/CpuLayout.java
@@ -5,7 +5,7 @@ import com.sun.jna.platform.win32.WinNT;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import me.cortex.voxy.common.Logger;
 import me.cortex.voxy.common.util.ThreadUtils;
-import org.lwjgl.system.Platform;
+import net.minecraft.Util;
 import oshi.SystemInfo;
 
 import java.util.Arrays;
@@ -24,8 +24,8 @@ public class CpuLayout {
     }
 
     public static void setThreadAffinity(Affinity... affinities) {
-        var platform = Platform.get();
-        if (platform == Platform.WINDOWS) {
+        var platform = Util.getPlatform();
+        if (platform == Util.OS.WINDOWS) {
             long[] msks = new long[affinities.length];
             short[] groups = new short[affinities.length];Arrays.fill(groups, (short) -1);
             int i = 0;
@@ -36,7 +36,7 @@ public class CpuLayout {
                 msks[idx] |= a.msk;
             }
             ThreadUtils.SetThreadSelectedCpuSetMasksWin32(Arrays.copyOf(msks, i), Arrays.copyOf(groups, i));
-        } else if (platform == Platform.LINUX) {
+        } else if (platform == Util.OS.LINUX) {
             Arrays.sort(affinities, (a, b) -> a.group - b.group);
             long[] msks = new long[affinities.length];
             for (int i=0; i<affinities.length; i++) {
@@ -130,9 +130,10 @@ public class CpuLayout {
     static {
         Core[] cores = null;
         try {
-            if (Platform.get() == Platform.WINDOWS) {
+            var platform = Util.getPlatform();
+            if (platform == Util.OS.WINDOWS) {
                 cores = generateCoreLayoutWindows();
-            } else if (Platform.get() == Platform.LINUX) {
+            } else if (platform == Util.OS.LINUX) {
                 cores = generateCoreLayoutLinux();
             }
         } catch (Exception e) {


### PR DESCRIPTION
Fixes an error when using WorldGen:
```
Exception in thread "Voxy-WorldGen-Worker" [11:24:57] [Voxy-WorldGen-Worker/INFO] [minecraft/LoggedPrintStream]: [STDERR]: java.lang.NoClassDefFoundError: org/lwjgl/system/Platform
[11:24:57] [Voxy-WorldGen-Worker/INFO] [minecraft/LoggedPrintStream]: [STDERR]:         at TRANSFORMER/voxy@0.2.14-alpha/me.cortex.voxy.common.util.cpu.CpuLayout.<clinit>(CpuLayout.java:133)
[11:24:57] [Voxy-WorldGen-Worker/INFO] [minecraft/LoggedPrintStream]: [STDERR]:         at TRANSFORMER/voxy@0.2.14-alpha/me.cortex.voxy.client.config.VoxyConfig.<init>(VoxyConfig.java:34)
[11:24:57] [Voxy-WorldGen-Worker/INFO] [minecraft/LoggedPrintStream]: [STDERR]:         at TRANSFORMER/voxy@0.2.14-alpha/me.cortex.voxy.client.config.VoxyConfig.loadOrCreate(VoxyConfig.java:74)
[11:24:57] [Voxy-WorldGen-Worker/INFO] [minecraft/LoggedPrintStream]: [STDERR]:         at TRANSFORMER/voxy@0.2.14-alpha/me.cortex.voxy.client.config.VoxyConfig.<clinit>(VoxyConfig.java:28)
[11:24:57] [Voxy-WorldGen-Worker/INFO] [minecraft/LoggedPrintStream]: [STDERR]:         at java.base/java.lang.Class.forName0(Native Method)
[11:24:57] [Voxy-WorldGen-Worker/INFO] [minecraft/LoggedPrintStream]: [STDERR]:         at java.base/java.lang.Class.forName(Class.java:421)
[11:24:57] [Voxy-WorldGen-Worker/INFO] [minecraft/LoggedPrintStream]: [STDERR]:         at java.base/java.lang.Class.forName(Class.java:412)
[11:24:57] [Voxy-WorldGen-Worker/INFO] [minecraft/LoggedPrintStream]: [STDERR]:         at TRANSFORMER/voxyworldgenv2@2.2.4/com.ethan.voxyworldgenv2.integration.VoxyIntegration.initialize(VoxyIntegration.java:76)
[11:24:57] [Voxy-WorldGen-Worker/INFO] [minecraft/LoggedPrintStream]: [STDERR]:         at TRANSFORMER/voxyworldgenv2@2.2.4/com.ethan.voxyworldgenv2.integration.VoxyIntegration.isVoxyRenderingEnabled(VoxyIntegration.java:170)
[11:24:57] [Voxy-WorldGen-Worker/INFO] [minecraft/LoggedPrintStream]: [STDERR]:         at TRANSFORMER/voxyworldgenv2@2.2.4/com.ethan.voxyworldgenv2.core.ChunkGenerationManager.workerLoop(ChunkGenerationManager.java:163)
[11:24:57] [Voxy-WorldGen-Worker/INFO] [minecraft/LoggedPrintStream]: [STDERR]:         at java.base/java.lang.Thread.run(Thread.java:1583)
[11:24:57] [Voxy-WorldGen-Worker/INFO] [minecraft/LoggedPrintStream]: [STDERR]: Caused by: java.lang.ClassNotFoundException: org.lwjgl.system.Platform
[11:24:57] [Voxy-WorldGen-Worker/INFO] [minecraft/LoggedPrintStream]: [STDERR]:         at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
[11:24:57] [Voxy-WorldGen-Worker/INFO] [minecraft/LoggedPrintStream]: [STDERR]:         at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
[11:24:57] [Voxy-WorldGen-Worker/INFO] [minecraft/LoggedPrintStream]: [STDERR]:         at cpw.mods.securejarhandler/cpw.mods.cl.ModuleClassLoader.loadClass(ModuleClassLoader.java:216)
[11:24:57] [Voxy-WorldGen-Worker/INFO] [minecraft/LoggedPrintStream]: [STDERR]:         at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
[11:24:57] [Voxy-WorldGen-Worker/INFO] [minecraft/LoggedPrintStream]: [STDERR]:         at cpw.mods.securejarhandler/cpw.mods.cl.ModuleClassLoader.loadClass(ModuleClassLoader.java:216)
[11:24:57] [Voxy-WorldGen-Worker/INFO] [minecraft/LoggedPrintStream]: [STDERR]:         at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
[11:24:57] [Voxy-WorldGen-Worker/INFO] [minecraft/LoggedPrintStream]: [STDERR]:         ... 11 more
```