### PR TITLE
Bundle Linux aarch64 natives for RocksDB and LWJGL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -277,7 +277,7 @@ tasks.register('makeExcludedRocksDB', Zip) {
         if (!file.endsWith(".so")) {
             return false
         }
-        return ["osx", "linux32", "musl", "s390x", "riscv64", "ppc64le", "aarch64"].any(file::contains)
+        return ["osx", "linux32", "musl", "s390x", "riscv64", "ppc64le"].any(file::contains)
     }
 }
 
@@ -329,6 +329,8 @@ dependencies {
     include(runtimeOnly "org.lwjgl:lwjgl-zstd:$lwjglVersion:natives-windows")
     include(runtimeOnly "org.lwjgl:lwjgl-lmdb:$lwjglVersion:natives-linux")
     include(runtimeOnly "org.lwjgl:lwjgl-zstd:$lwjglVersion:natives-linux")
+    include(runtimeOnly "org.lwjgl:lwjgl-lmdb:$lwjglVersion:natives-linux-arm64")
+    include(runtimeOnly "org.lwjgl:lwjgl-zstd:$lwjglVersion:natives-linux-arm64")
 
     include(implementation 'redis.clients:jedis:5.1.0')
     include(implementation('org.rocksdb:rocksdbjni:10.2.1'))


### PR DESCRIPTION
# Summary
Addresses [#186](https://github.com/m3t4f1v3/voxy/issues/186):
Upstream gates multi-platform `rocksdbjni` jar behind `-PincludeOtherArchs=true` to keep default jars smaller. This PR bundles **linux aarch64 only** by default instead. The upstream flag can be ported later for parity if desired.

# Windows ARM64
Voxy's storage depends on RocksDB JNI, and `rocksdbjni` 10.2.1 only ships `librocksdbjni-win64.dll`.

Upstream work is in progress: [facebook/rocksdb#14699](https://github.com/facebook/rocksdb/pull/14699) adds `win-arm64` support to `rocksdbjni`. Once that lands and is published, we can bundle `librocksdbjni-win-arm64.dll` and add LWJGL `natives-windows-arm64` in a follow-up.