### PR TITLE
fix: resolve multiplayer cache path always being UNKNOWN

### DIFF
--- a/src/main/java/me/cortex/voxy/client/ClientSessionEvents.java
+++ b/src/main/java/me/cortex/voxy/client/ClientSessionEvents.java
@@ -3,12 +3,18 @@ package me.cortex.voxy.client;
 import me.cortex.voxy.client.config.VoxyConfig;
 import me.cortex.voxy.commonImpl.VoxyCommon;
 
+import java.nio.file.Path;
+
 public class ClientSessionEvents {
     public static boolean inSession = false;
 
-    public static void sessionStart() {
+    // Full storage base path computed at handleLogin time, when all APIs are available.
+    private static Path cachedBasePath;
+
+    public static void sessionStart(Path basePath) {
         if (inSession) throw new IllegalStateException("Cannot start new session while in a session");
         inSession = true;
+        ClientSessionEvents.cachedBasePath = basePath;
 
         //Should never try creating multiple instances via session start
         if (VoxyCommon.getInstance() != null) throw new IllegalStateException();
@@ -20,9 +26,17 @@ public class ClientSessionEvents {
         }
     }
 
+    /**
+     * Returns the base path computed at login time, or null if not in a session.
+     */
+    public static Path getCachedBasePath() {
+        return cachedBasePath;
+    }
+
     public static void sessionEnd() {
         if (!inSession) throw new IllegalStateException("Cannot end a session while not in a session");
         inSession = false;
+        cachedBasePath = null;
 
         VoxyCommon.shutdownInstance();
     }

--- a/src/main/java/me/cortex/voxy/client/VoxyClientInstance.java
+++ b/src/main/java/me/cortex/voxy/client/VoxyClientInstance.java
@@ -7,19 +7,13 @@ import me.cortex.voxy.client.mixin.sodium.AccessorSodiumWorldRenderer;
 import me.cortex.voxy.common.Logger;
 import me.cortex.voxy.common.StorageConfigUtil;
 import me.cortex.voxy.common.config.ConfigBuildCtx;
-import me.cortex.voxy.common.config.Serialization;
-import me.cortex.voxy.common.config.compressors.ZSTDCompressor;
-import me.cortex.voxy.common.config.section.SectionSerializationStorage;
 import me.cortex.voxy.common.config.section.SectionStorage;
 import me.cortex.voxy.common.config.section.SectionStorageConfig;
-import me.cortex.voxy.common.config.storage.other.CompressionStorageAdaptor;
-import me.cortex.voxy.common.config.storage.rocksdb.RocksDBStorageBackend;
 import me.cortex.voxy.commonImpl.ImportManager;
 import me.cortex.voxy.commonImpl.VoxyInstance;
 import me.cortex.voxy.commonImpl.WorldIdentifier;
 import me.jellysquid.mods.sodium.client.render.SodiumWorldRenderer;
 import net.minecraft.client.Minecraft;
-import net.minecraft.world.level.storage.LevelResource;
 import java.nio.file.Path;
 
 public class VoxyClientInstance extends VoxyInstance {
@@ -99,29 +93,14 @@ public class VoxyClientInstance extends VoxyInstance {
     }
 
     private static Path getBasePath() {
-        Path basePath = Minecraft.getInstance().gameDirectory.toPath().resolve(".voxy").resolve("saves");
-        var iserver = Minecraft.getInstance().getSingleplayerServer();
-        if (iserver != null) {
-            basePath = iserver.getWorldPath(LevelResource.ROOT).resolve("voxy");
-        } else {
-            var netHandle = Minecraft.getInstance().gameMode;
-            if (netHandle == null) {
-                Logger.error("Network handle null");
-                basePath = basePath.resolve("UNKNOWN");
-            } else {
-                var info = netHandle.connection.getServerData();
-                if (info == null) {
-                    Logger.error("Server info null");
-                    basePath = basePath.resolve("UNKNOWN");
-                } else {
-                    if (Minecraft.getInstance().isConnectedToRealms()) {
-                        basePath = basePath.resolve("realms");
-                    } else {
-                        basePath = basePath.resolve(info.ip.replace(":", "_"));
-                    }
-                }
-            }
+        // The base path is pre-computed by MixinClientPacketListener at handleLogin time,
+        // when all Minecraft APIs (getSingleplayerServer, getServerData) are available.
+        var cached = ClientSessionEvents.getCachedBasePath();
+        if (cached != null) {
+            return cached.toAbsolutePath();
         }
-        return basePath.toAbsolutePath();
+        // Fallback: should not normally happen
+        Logger.error("Cached base path not available, using UNKNOWN");
+        return Minecraft.getInstance().gameDirectory.toPath().resolve(".voxy").resolve("saves").resolve("UNKNOWN").toAbsolutePath();
     }
 }

--- a/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinClientPacketListener.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinClientPacketListener.java
@@ -1,19 +1,53 @@
 package me.cortex.voxy.client.mixin.minecraft;
 
 import me.cortex.voxy.client.ClientSessionEvents;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.client.multiplayer.ServerData;
 import net.minecraft.network.protocol.game.ClientboundLoginPacket;
+import net.minecraft.world.level.storage.LevelResource;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.nio.file.Path;
+
 @Mixin(ClientPacketListener.class)
 public class MixinClientPacketListener {
+    @Shadow
+    private ServerData serverData;
+
     @Inject(method = "handleLogin", at = @At("HEAD"))
     private void voxy$init(ClientboundLoginPacket packet, CallbackInfo ci) {
         if (!ClientSessionEvents.inSession) {
-            ClientSessionEvents.sessionStart();
+            ClientSessionEvents.sessionStart(resolveBasePath());
         }
+    }
+
+    private Path resolveBasePath() {
+        var mc = Minecraft.getInstance();
+        Path basePath = mc.gameDirectory.toPath().resolve(".voxy").resolve("saves");
+
+        var iserver = mc.getSingleplayerServer();
+        if (iserver != null) {
+            // Singleplayer: store in the world's own directory
+            return iserver.getWorldPath(LevelResource.ROOT).resolve("voxy");
+        }
+
+        if (mc.isConnectedToRealms()) {
+            return basePath.resolve("realms");
+        }
+
+        // Multiplayer: use the server IP from ClientPacketListener.serverData
+        // which is available at handleLogin time (set in the constructor).
+        var self = (ClientPacketListener)(Object)this;
+        var info = self.getServerData();
+        if (info != null) {
+            return basePath.resolve(info.ip.replace(":", "_"));
+        }
+
+        return basePath.resolve("UNKNOWN");
     }
 }


### PR DESCRIPTION
getBasePath() was called during handleLogin when gameMode is not yet initialized, causing all multiplayer servers and singleplayer worlds to fall into the UNKNOWN branch.

Fix by computing the full storage base path in MixinClientPacketListener at handleLogin time (when getSingleplayerServer and getServerData are both available), caching it in ClientSessionEvents, and having VoxyClientInstance.getBasePath() read directly from the cache.