### PR TITLE
Fix rasterizer math + change rendering injection to HEAD

### DIFF
--- a/src/main/java/me/cortex/voxy/client/core/model/bakery/SoftwareRasterizer.java
+++ b/src/main/java/me/cortex/voxy/client/core/model/bakery/SoftwareRasterizer.java
@@ -151,7 +151,7 @@ public class SoftwareRasterizer {
                 float w1 = edge(v2, v3, cx, cy)*invArea;
                 float w2 = edge(v3, v1, cx, cy)*invArea;
                 float w3 = 1.0f-w1-w2;
-                if ((w1>0.0f&&w2>0.0f&&w3>0.0f)||(orZero&&w1>=0.0f&&w2>=0.0f&&w3>=0.0f)) {
+                if (w1>=0.0f&&w2>=0.0f&&w3>=0.0f) {
                     //Dont need to worry about perspective correction afak as it should already be all correct
 
                     //pixel is inside the triangle

--- a/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinRenderSystem.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinRenderSystem.java
@@ -15,7 +15,7 @@ import java.util.function.BiFunction;
 @Mixin(RenderSystem.class)
 public class MixinRenderSystem {
     //We need to inject before iris to initalize our systems
-    @Inject(method = "initRenderer", remap = false, at = @At("RETURN"))
+    @Inject(method = "initRenderer", remap = false, at = @At("HEAD"))
     private static void voxy$injectInit(int debugVerbosity, boolean sync, CallbackInfo ci) {
         VoxyClient.initVoxyClient();
     }


### PR DESCRIPTION
fix for the diagonal line seam on surfaces with the rasterizer

and changed the rendering injection to HEAD to prevent iris from touching anything before Voxy is ready (and preventing configs to load on startup when shaders are enabled)