### PR TITLE
Fix 1.20.1 Forge startup crash and UNKNOWN storage path

### DIFF
--- a/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinClientLevel.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinClientLevel.java
@@ -5,7 +5,6 @@ import me.cortex.voxy.common.world.service.VoxelIngestService;
 import me.cortex.voxy.commonImpl.VoxyCommon;
 import me.cortex.voxy.commonImpl.VoxyInstance;
 import me.cortex.voxy.commonImpl.WorldIdentifier;
-import net.minecraft.client.multiplayer.ClientChunkCache;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.client.renderer.LevelRenderer;
@@ -22,9 +21,7 @@ import net.minecraft.world.level.dimension.DimensionType;
 
 import java.util.function.Supplier;
 
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -35,10 +32,6 @@ public abstract class MixinClientLevel {
 
     @Unique
     private int bottomSectionY;
-
-    @Shadow @Final public LevelRenderer levelRenderer;
-
-    @Shadow public abstract ClientChunkCache getChunkSource();
 
     @Inject(method = "<init>", at = @At("TAIL"))
     private void voxy$getBottom(

--- a/versions/1.20.1/src/java/me/cortex/voxy/client/mixin/minecraft/MixinClientPacketListener.java
+++ b/versions/1.20.1/src/java/me/cortex/voxy/client/mixin/minecraft/MixinClientPacketListener.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(ClientPacketListener.class)
 public class MixinClientPacketListener {
-    @Inject(method = "handleLogin", at = @At("HEAD"))
+    @Inject(method = "handleLogin", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Minecraft;setLevel(Lnet/minecraft/client/multiplayer/ClientLevel;)V", shift = At.Shift.BEFORE))
     private void voxy$init(ClientboundLoginPacket packet, CallbackInfo ci) {
         if (!ClientSessionEvents.inSession) {
             ClientSessionEvents.sessionStart();


### PR DESCRIPTION
## Summary

Fixes two issues specific to the 1.20.1 Forge (legacy MCPConfig/SRG) target: a startup crash from unresolved mixin shadows, and Voxy silently falling back to an `UNKNOWN` save folder (and, in an earlier iteration of this fix, failing to load LODs at all) on server join.

## Fix 1: Startup crash — `MixinClientLevel.java`

Two `@Shadow` members were declared but never referenced anywhere in the mixin:

```java
@Shadow @Final public LevelRenderer levelRenderer;
@Shadow public abstract ClientChunkCache getChunkSource();
```

Under the legacy Forge toolchain (named/MCP mappings at compile time vs. SRG names at runtime), Mixin resolves every `@Shadow` member through the generated refmap. The annotation processor does not emit a refmap entry for shadow members that are never called, so `getChunkSource` had no mapping — Mixin's shadow validation failed to resolve it against the SRG-named runtime class, crashing the game on mixin apply. Fabric never hit this because compile-time and runtime names already match there.

**Fix:** removed both unused `@Shadow` declarations and their now-dead imports (`ClientChunkCache`, `Shadow`, `Final`). This is a root-cause fix, not a refmap patch — there's nothing left that needs shadow resolution.

## Fix 2: `UNKNOWN` save folder / LODs not loading — `MixinClientPacketListener.java` (1.20.1)

```java
@Inject(method = "handleLogin", at = @At("HEAD"))
private void voxy$init(...) {
    if (!ClientSessionEvents.inSession) ClientSessionEvents.sessionStart();
}
```

`ClientSessionEvents.sessionStart()` creates `VoxyClientInstance`, whose constructor derives the save path from `Minecraft.gameMode.connection.getServerData()`. Decompiling `ClientPacketListener#handleLogin` (SRG `m_5998_`) for 1.20.1:

```java
public void handleLogin(ClientboundLoginPacket p) {
    PacketUtils.ensureRunningOnSameThread(...);
    this.minecraft.gameMode = new MultiPlayerGameMode(...);   // 2nd statement
    ...
    this.level = new ClientLevel(...);
    this.minecraft.setLevel(this.level, ...);                  // → LevelRenderer.setLevel → allChanged()
    ...
}
```

At `@At("HEAD")`, `gameMode` is still `null` (it's assigned on the next line), so the ctor takes its null-check branch and the save folder becomes `UNKNOWN` instead of `[serverId]`.

An initial attempt moved the injection to `@At("TAIL")`. That fixed the save path, but broke rendering: `Minecraft.setLevel()` synchronously calls `LevelRenderer.allChanged()`, which is where Voxy actually constructs its render system (`MixinLevelRenderer.voxy$createRenderer`, gated on `VoxyCommon.getInstance() != null`). With instance creation deferred to `TAIL`, `allChanged()` fires before the instance exists, so renderer creation is skipped (logged, no crash) and never retried — no LODs load until a manual Voxy toggle re-triggers it.

**Fix:** anchor the injection precisely between those two events:

```java
@Inject(method = "handleLogin", at = @At(value = "INVOKE",
    target = "Lnet/minecraft/client/Minecraft;setLevel(Lnet/minecraft/client/multiplayer/ClientLevel;)V",
    shift = At.Shift.BEFORE))
```

Fires after `gameMode` is assigned but before `setLevel`/`allChanged` runs — save path resolves correctly and the renderer initializes on first join.

## Testing

- Fresh join on a multiplayer server: save folder now named after the server (not `UNKNOWN`), LODs load immediately without needing to toggle Voxy off/on.
- Singleplayer unaffected (uses a different save-path branch that doesn't depend on `gameMode`).