### PR TITLE
Defer Voxy render system creation off the network packet thread

### DIFF
--- a/src/main/java/me/cortex/voxy/client/core/VoxyRenderSystem.java
+++ b/src/main/java/me/cortex/voxy/client/core/VoxyRenderSystem.java
@@ -103,8 +103,6 @@ public class VoxyRenderSystem {
         world.acquireRef();
         Logger.info("Creating Voxy render system");
 
-        System.gc();
-
         if (Minecraft.getInstance().options.renderDistance().get()<3) {
             String msg = "Voxy: Having a vanilla render distance of 2 can cause rare culling near the edge of your screen issues, please use 3 or more";
             Logger.warn(msg);

--- a/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinLevelRenderer.java
+++ b/src/main/java/me/cortex/voxy/client/mixin/minecraft/MixinLevelRenderer.java
@@ -9,6 +9,7 @@ import me.cortex.voxy.common.Logger;
 import me.cortex.voxy.common.world.WorldEngine;
 import me.cortex.voxy.commonImpl.VoxyCommon;
 import me.cortex.voxy.commonImpl.WorldIdentifier;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.LevelRenderer;
 import org.jetbrains.annotations.Nullable;
@@ -33,7 +34,16 @@ public abstract class MixinLevelRenderer implements IGetVoxyRenderSystem {
     private void voxy$reloadVoxyRenderer(CallbackInfo ci) {
         this.voxy$shutdownRenderer();
         if (this.level != null) {
-            this.voxy$createRenderer();
+            //Defer the actual (heavy, GL-bound) creation by one loop iteration instead of running it
+            // synchronously here. allChanged() runs inside the network packet handling call stack
+            // (ClientPacketListener#handleLogin), so blocking here delays that packet handler from
+            // returning and stalls processing of any other packets queued behind it.
+            var scheduledLevel = this.level;
+            Minecraft.getInstance().execute(() -> {
+                if (this.level == scheduledLevel && this.renderer == null) {
+                    this.voxy$createRenderer();
+                }
+            });
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes a race condition on server join where mods that send custom payload packets early in the connection sequence (observed with dragonlib) can hit a server-side network handler that isn't initialized yet, throwing `IllegalStateException: NetworkThreadPool not initialized or already shut down`. Verified via A/B test: reliably reproduces with Voxy enabled, never without it. Voxy never appears in the resulting stacktrace — it doesn't cause the error directly, it delays the render thread long enough on join that a timing window opens which is otherwise never visible.

Root cause: Voxy's world-engine + render-system initialization ran synchronously inside `LevelRenderer#allChanged()`, which itself runs inside `ClientPacketListener#handleLogin` (i.e. inside the network packet handling call stack). That blocks `handleLogin` from returning, which stalls processing of any packets queued behind it — including the other mod's early packet.

## Fix 1: Remove unnecessary `System.gc()` — `VoxyRenderSystem.java`

```java
public VoxyRenderSystem(WorldEngine world, ServiceManager sm) {
    world.acquireRef();
    Logger.info("Creating Voxy render system");

    System.gc();
    ...
```

`System.gc()` ran right before the multi-GB sparse geometry buffer allocation, presumably as a "free up memory first" precaution. It doesn't actually help: the geometry buffer is allocated via OpenGL (`glBufferStorage`, GPU memory), not the Java heap, so a Java GC has no direct bearing on whether that allocation succeeds. What it does reliably do is block the calling thread for an unpredictable amount of time — a full stop-the-world collection can take anywhere from a few ms to 500ms+ depending on heap occupancy. Since this constructor runs inside the packet-handling call stack described above, this was pure, unjustified time added to the critical section.

**Fix:** removed the call. No functional dependency on it — the existing GL-error handling / sparse-buffer fallback path already covers allocation failures.

## Fix 2: Defer render system creation off the packet thread — `MixinLevelRenderer.java`

```java
@Inject(method = "allChanged()V", at = @At("RETURN"), order = 900)
private void voxy$reloadVoxyRenderer(CallbackInfo ci) {
    this.voxy$shutdownRenderer();
    if (this.level != null) {
        this.voxy$createRenderer();
    }
}
```

`voxy$createRenderer()` does the actual heavy lifting: creates the `WorldEngine` (opens the on-disk storage backend), then constructs `VoxyRenderSystem` (GL buffer/texture allocation, shader pipeline compile, `glFinish()` calls) and starts Voxy's dedicated worker threads. All of it ran synchronously here, i.e. still inside `handleLogin`.

**Fix:** the actual creation is now scheduled via `Minecraft.getInstance().execute(...)` instead of called directly, so it runs on the next main-loop iteration rather than inside the packet handler's call stack:

```java
var scheduledLevel = this.level;
Minecraft.getInstance().execute(() -> {
    if (this.level == scheduledLevel && this.renderer == null) {
        this.voxy$createRenderer();
    }
});
```

Two guards on the deferred task: `this.level == scheduledLevel` discards the task if the level changed again before it ran (e.g. a fast reconnect/dimension change), and `this.renderer == null` prevents double-creation if a newer task already ran first. This keeps the work on the same thread (still required for the GL calls) but moves it out of the current call stack, letting `handleLogin` return immediately so the client's main loop gets a chance to drain any packets that arrived in the meantime before Voxy's expensive init chain runs.

## Testing

- Joining a server that sends early custom payload packets (dragonlib): no longer crashes with `NetworkThreadPool not initialized`.
- Normal server join: Voxy initializes and renders LODs as before, no regression observed. Render system creation lands one frame later than previously (imperceptible in practice; all consumers of `voxy$getRenderSystem()` already null-check).
- Singleplayer unaffected.